### PR TITLE
[#23] 11051 이항 계수 2

### DIFF
--- a/ningpop/11051.py
+++ b/ningpop/11051.py
@@ -1,0 +1,24 @@
+# 2022.04.18
+# 풀이 시간 15분 45초
+# 채점 결과: 정답
+# 시간복잡도: O(2^N)
+# 문제 링크: https://www.acmicpc.net/problem/11051
+
+import sys
+
+input = sys.stdin.readline
+
+def factorial(n: int) -> int:
+    if n == 0:
+        return 1
+    if n <= 2:
+        return n
+    result = 1
+    for i in range(2, n + 1):
+        result *= i
+    return result
+
+n, k = map(int, input().split())
+
+result = factorial(n) // (factorial(n - k) * factorial(k))
+print(int(result % 10007))


### PR DESCRIPTION
## 문제 번호
closed #23 

## 풀이 사항
- 풀이 일자: 2022.04.18
- 풀이 시간 15분 45초
- 채점 결과: 정답
- 시간복잡도: O(2^N)
- 문제 링크: https://www.acmicpc.net/problem/11051

## 기타 특이 사항
1. python의 combination 모듈을 써서 했다가 메모리 초과가 났어요
2. k가 0인 경우를 고려하지 않아서 런타임 에러(ZeroDivisionError)가 났어요
3. n! / (n-k)! * k! 를 구할 때, 나눗셈에서 그냥 소수로 나눠버리고 int로 형변환 하는 방식을 썼다가 틀렸어요
4. 몫만 취하는 연산으로 바꿨더니 맞았어요