### PR TITLE
[#34] 11659 구간 합 구하기 4

### DIFF
--- a/ningpop/11659.py
+++ b/ningpop/11659.py
@@ -1,0 +1,20 @@
+# 2022.04.20
+# 풀이 시간 32분 00초
+# 채점 결과: 시간 초과 -> 정답
+# 시간복잡도: O(N)
+# 문제 링크: https://www.acmicpc.net/problem/11659
+
+import sys
+
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+array = [0] + list(map(int, input().split()))
+
+memo = [ 0 for _ in range(n + 1) ]
+for i in range(1, n + 1):
+    memo[i] = array[i] + memo[i - 1]
+
+for _ in range(m):
+    i, j = map(int, input().split())
+    print(memo[j] - memo[i - 1])


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #34 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.04.20
- 풀이 시간: 32분 00초
- 채점 결과: 시간 초과 -> 정답
- 시간복잡도: O(N)
- 문제 링크: https://www.acmicpc.net/problem/11659

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
1. 일반적인 슬라이싱으로 접근했다가 시간초과가 났습니다.
2. 메모이제이션을 생각하고 약간의 시간을 줄이고자 구했던 구간을 재활용하는 방법을 시도했지만 시간초과가 났습니다.
3. 누적합 잔스킬을 사용했더니 정답처리 되었습니다.