### PR TITLE
[#52] 14476 최대공약수 하나 빼기

### DIFF
--- a/ningpop/14476.py
+++ b/ningpop/14476.py
@@ -1,0 +1,43 @@
+# 2022.04.24
+# 풀이 시간 40분 00초
+# 채점 결과: 메모리 초과 -> 시간 초과 -> 정답
+# 시간복잡도: O(N)
+# 문제 링크: https://www.acmicpc.net/problem/14476
+
+import sys
+from math import gcd
+
+input = sys.stdin.readline
+
+n = int(input())
+numbers = list(map(int, input().split()))
+
+left_gcd = [0] * len(numbers)
+left_gcd[0] = numbers[0]
+right_gcd = [0] * len(numbers)
+right_gcd[-1] = numbers[-1]
+for i in range(1, len(numbers)):
+    left_gcd[i] = gcd(left_gcd[i - 1], numbers[i])
+for i in range(len(numbers) - 2, -1, -1):
+    right_gcd[i] = gcd(right_gcd[i + 1], numbers[i])
+
+maximum = (-1, -1)
+for i in range(len(numbers)):
+    result = -1
+    if i == 0:
+        result = right_gcd[1]
+    elif i == len(numbers) - 1:
+        result = left_gcd[len(numbers) - 2]
+    else:
+        result = gcd(left_gcd[i - 1], right_gcd[i + 1])
+
+    if numbers[i] % result == 0:
+        continue
+    
+    if maximum[0] < result:
+        maximum = (result, numbers[i])
+
+if maximum == (-1, -1):
+    print(-1)
+else:
+    print(*maximum)


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #52 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.04.24
- 풀이 시간: 40분 00초
- 채점 결과: 메모리 초과 -> 시간 초과 -> 정답
- 시간복잡도: O(N)
- 문제 링크: https://www.acmicpc.net/problem/14476

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
유클리드 호제법을 사용하여 풀이하였습니다.
1. 조합을 이용하여 경우의 수들을 뽑고 반복하여 풀었더니 메모리 초과가 나왔습니다.
2. 조합을 이용하지 않고 수를 뺀 경우를 그때그때 계산하니 시간 초과가 나왔습니다.
3. 누적합 개념을 접목시켜 누적 최대공약수를 저장할 수 있는 배열을 만들고 꺼내 쓰니 정답처리 되었습니다.

P.S.) 파이썬의 math 모듈에 gcd가 내장되어있다니... 갓-파이썬...