### PR TITLE
[#54] 1010 다리 놓기

### DIFF
--- a/ningpop/1010.py
+++ b/ningpop/1010.py
@@ -1,0 +1,30 @@
+# 2022.04.25
+# 풀이 시간 31분 55초
+# 채점 결과: 시간 초과 -> 정답
+# 시간복잡도: O(2^N)
+# 문제 링크: https://www.acmicpc.net/problem/1010
+
+import sys
+
+input = sys.stdin.readline
+
+def factorial(n: int) -> int:
+    global memo
+    if memo[n] != 0:
+        return memo[n]
+    
+    for i in range(n - 1, 0, -1):
+        if memo[i] != 0:
+            for j in range(i + 1, n + 1):
+                memo[j] = memo[j - 1] * j
+            break
+    return memo[n]
+
+t = int(input())
+memo = [0] * 30
+memo[0] = 1
+memo[1] = 1
+for _ in range(t):
+    n, m = map(int, input().split())
+    result = factorial(m) // (factorial(m - n) * factorial(n))
+    print(result)


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #54 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.04.25
- 풀이 시간: 31분 55초
- 채점 결과: 시간 초과 -> 정답
- 시간복잡도: O(2^N)
- 문제 링크: https://www.acmicpc.net/problem/1010

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
1. 조합을 이용하면 된다는 것을 깨닫고 python의 combination모듈을 사용하였으나 시간 초과가 나왔습니다.
2. 경우의 수 리스트를 계속 만드는것은 비효율적이라는 것을 확인하고, nCr 공식을 이용하여 정답처리 되었습니다.
(팩토리얼 계산 시 memoization을 활용하였습니다.)