### PR TITLE
[#67] 11660 구간 합 구하기 5

### DIFF
--- a/ningpop/11660.py
+++ b/ningpop/11660.py
@@ -1,0 +1,24 @@
+# 2022.04.27
+# 풀이 시간 52분 55초
+# 채점 결과: 시간 초과 -> 정답
+# 시간복잡도: O(M*N^2)
+# 문제 링크: https://www.acmicpc.net/problem/11660
+
+import sys
+
+input = sys.stdin.readline
+
+n, m = map(int, input().split())
+array = [ [0] * (n + 1) ]
+for _ in range(n):
+    array.append([0] + list(map(int, input().split())))
+
+data = [ [0] * (n + 1) for _ in range(n + 1) ]
+for i in range(1, n + 1):
+    for j in range(1, n + 1):
+        data[i][j] = data[i][j - 1] + data[i - 1][j] - data[i - 1][j - 1] + array[i][j]
+
+for _ in range(m):
+    x1, y1, x2, y2 = map(int, input().split())
+    result = data[x2][y2] - data[x1 - 1][y2] - data[x2][y1 - 1] + data[x1 - 1][y1 - 1]
+    print(result)


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #67 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.04.27
- 풀이 시간: 52분 55초
- 채점 결과: 시간 초과 -> 정답
- 시간복잡도: O(M * N^2)
- 문제 링크: https://www.acmicpc.net/problem/11660

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
구간 합 구하기를 활용하여 구간 합 테이블을 만들어 사용하였습니다.
1. 구간 합 테이블을 만들 때, 가로방향의 구간 합만 계산/저장하였고, 시간 초과되었습니다.
2. 조금 더 고민 후 다른 사람의 풀이를 보고 가로/세로 모두 포함한 대각선 방향의 구간 합 테이블을 만들어 사용하였고, 정답처리 되었습니다.