### PR TITLE
[#73] 1062 가르침 - 미해결

### DIFF
--- a/ningpop/1062.py
+++ b/ningpop/1062.py
@@ -1,0 +1,24 @@
+# 2022.04.28
+# 풀이 시간 92분 48초
+# 채점 결과: 시간 초과
+# 시간복잡도: 
+# 문제 링크: https://www.acmicpc.net/problem/1062
+
+import sys
+from itertools import combinations
+
+input = sys.stdin.readline
+
+n, k = map(int, input().split())
+words = []
+for _ in range(n):
+    words.append(input().rstrip())
+
+if k < 5:
+    print(0)
+else:
+    leared_bit = ['0'] * 26
+    for c in ['a', 'c', 'i', 'n', 't']:
+        leared_bit[ord(c) - 97] = '1'
+    leared_bit = bin(''.join(leared_bit))
+    print(leared_bit)


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
#73 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.04.28
- 풀이 시간: 92분 48초
- 채점 결과: 시간 초과, 오답
- 시간복잡도: 
- 문제 링크: https://www.acmicpc.net/problem/1062

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
1. 모든 경우의 수를 구해 브루트포스로 접근하였더니 시간초과가 났습니다.
2. 풀이들을 보고 dfs를 사용한 백트래킹 기법 풀이는 이해하였으나, 비트마스킹 풀이를 이해하지 못했습니다.
-> 나중에 다시 풀어보겠습니다.