### PR TITLE
BOJ 1991

### DIFF
--- a/keich_park/1991.kt
+++ b/keich_park/1991.kt
@@ -1,0 +1,33 @@
+fun main() {
+    val n = readLine()?.toInt() ?: return
+    val nodes = mutableMapOf<String, Pair<String?, String?>>()
+    repeat(n) {
+        val (root, left, right) = readLine()?.split(' ') ?: return
+        nodes[root] = Pair(
+            if (left == ".") null else left,
+            if (right == ".") null else right,
+        )
+    }
+
+    println(prefix(nodes, "A"))
+    println(infix(nodes, "A"))
+    println(postfix(nodes, "A"))
+}
+
+fun prefix(nodes: Map<String, Pair<String?, String?>>, node: String): String {
+    return node +
+            (nodes[node]?.first?.let { prefix(nodes, it) } ?: "") +
+            (nodes[node]?.second?.let { prefix(nodes, it) } ?: "")
+}
+
+fun infix(nodes: Map<String, Pair<String?, String?>>, node: String): String {
+    return (nodes[node]?.first?.let { infix(nodes, it) } ?: "") +
+            node +
+            (nodes[node]?.second?.let { infix(nodes, it) } ?: "")
+}
+
+fun postfix(nodes: Map<String, Pair<String?, String?>>, node: String): String {
+    return (nodes[node]?.first?.let { postfix(nodes, it) } ?: "") +
+            (nodes[node]?.second?.let { postfix(nodes, it) } ?: "") +
+            node
+}


### PR DESCRIPTION
## 문제 번호
1991 트리 순회

## 풀이 사항
- 풀이 일자: 2022.04.29
- 풀이 시간: 15분
- 채점 결과: 정답
- 시간복잡도: N
- 문제 링크: https://www.acmicpc.net/problem/1991