### PR TITLE
BOJ 3955

### DIFF
--- a/keich_park/3955.kt
+++ b/keich_park/3955.kt
@@ -1,0 +1,52 @@
+fun main() {
+    val t = readLine()?.toInt() ?: return
+    repeat(t) {
+        val (k, c) = readLine()?.split(' ')?.map { it.toInt() } ?: return
+
+        if (c == 1) {
+            if (k+1 > 1000000000) println("IMPOSSIBLE")
+            else println(k + 1)
+        } else if (k == 1) {
+            println(1)
+        } else {
+            val (gcd, s, t) = exEuclid(k, c)
+
+            if (gcd != 1) {
+                println("IMPOSSIBLE")
+            } else {
+                val result = (t % k + k) % k
+                println(result)
+            }
+        }
+    }
+}
+
+fun exEuclid(a: Int, b: Int): Triple<Int, Int, Int> {
+    var q = 0
+    var r = 0
+    var r1 = a
+    var r2 = b
+    var s1 = 1
+    var s2 = 0
+    var s = 0
+    var t1 = 0
+    var t2 = 1
+    var t = 0
+
+    while (r2 > 0) {
+        q = r1 / r2
+        r = r1 - q * r2
+        r1 = r2
+        r2 = r
+
+        s = s1 - q * s2
+        s1 = s2
+        s2 = s
+
+        t = t1 - q * t2
+        t1 = t2
+        t2 = t
+    }
+
+    return Triple(r1, s1, t1)
+}


### PR DESCRIPTION
## 문제 번호
3955번 사탕 분배

## 풀이 사항
- 풀이 일자: 2022.05.01
- 풀이 시간: 120분
- 채점 결과: 정답
- 시간복잡도: 
- 문제 링크: https://www.acmicpc.net/problem/3955

## 기타 특이 사항
확장 유클리드 호제법 사용.
해당 알고리즘을 이해하기 위한 추가적인 공부 필요