### PR TITLE
[#96] 2579 계단 오르기

### DIFF
--- a/ningpop/2579.py
+++ b/ningpop/2579.py
@@ -1,0 +1,25 @@
+# 2022.05.05
+# 풀이 시간 47분 43초
+# 채점 결과: 런타임 에러 -> 정답
+# 시간복잡도: O(N)
+# 문제 링크: https://www.acmicpc.net/problem/2579
+
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+stairs = []
+for _ in range(n):
+    stairs.append(int(input()))
+
+if n == 1:
+    print(stairs[-1])
+else:
+    dp = [0] * n
+    dp[0] = stairs[0]
+    dp[1] = stairs[0] + stairs[1]
+    for i in range(2, n):
+        dp[i] = max(dp[i - 3] + stairs[i - 1], dp[i - 2]) + stairs[i]
+
+    print(dp[-1])


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #96 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.05.05
- 풀이 시간: 47분 43초
- 채점 결과: 런타임 에러 -> 정답
- 시간복잡도: O(N)
- 문제 링크: https://www.acmicpc.net/problem/2579

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
1. 점화식을 못세우고 고민하다가 풀이를 보았습니다.(코드가 아닌 점화식만 봄)
2. n이 1일때를 처리하지 않아 런타임에러가 났습니다.
3. n이 1일때를 처리해주고 정답처리 되었습니다.