### PR TITLE
[#123] 2458 키 순서

### DIFF
--- a/ningpop/2458.py
+++ b/ningpop/2458.py
@@ -1,0 +1,45 @@
+# 2022.05.10
+# 풀이 시간 38분 00초
+# 채점 결과: 시간초과(Python3), 정답(Pypy3)
+# 시간복잡도: O(N^3)
+# 문제 링크: https://www.acmicpc.net/problem/2458
+
+import sys
+
+input = sys.stdin.readline
+INF = 1E9
+
+n, m = map(int, input().split())
+graph = [ [INF] * (n + 1) for _ in range(n + 1) ]
+
+for a in range(1, n + 1):
+    for b in range(1, n + 1):
+        if a == b:
+            graph[a][b] = 0
+
+for _ in range(m):
+    a, b = map(int, input().split())
+    if graph[a][b] == INF:
+        graph[a][b] = 0
+    else:
+        graph[a][b] += 1
+
+for k in range(1, n + 1):
+    for a in range(1, n + 1):
+        for b in range(1, n + 1):
+            graph[a][b] = min(graph[a][b], graph[a][k] + graph[k][b])
+
+answer_array = [ i for i in range(1, n + 1) ]
+result = 0
+for i in range(1, n + 1):
+    array = set()
+    for j in range(1, n + 1):
+        if graph[i][j] != INF:
+            array.add(j)
+    for j in range(1, n + 1):
+        if graph[j][i] != INF:
+            array.add(j)
+    if sorted(list(array)) == answer_array:
+        result += 1
+
+print(result)


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
closed #123 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.05.10
- 풀이 시간: 38분 00초
- 채점 결과: 시간초과(Python3), 정답(Pypy3)
- 시간복잡도: O(N^3)
- 문제 링크: https://www.acmicpc.net/problem/2458

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
플로이드워셜을 사용해서 모든 노드로부터 모든 노드로의 길이표를 구한 뒤, 특정 노드에서 다른 노드로 나가는 경우와 특정 노드로 들어오는 경우를 합했을 때, N개의 노드들과 같다면 순서를 알 수 있다는 접근으로 풀이했습니다.
1. Python3로 풀이했더니 시간초과 처리되었습니다.
2. Pypy3로 풀이했더니 정답처리 되었습니다.