### PR TITLE
[#145] 11049 행렬 곱셈 순서

### DIFF
--- a/ningpop/11049.py
+++ b/ningpop/11049.py
@@ -1,0 +1,29 @@
+# 2022.05.18
+# 풀이 시간 93분 45초
+# 채점 결과: 시간 초과(Python3), 정답(Pypy3)
+# 시간복잡도: O(N^3)
+# 문제 링크: https://www.acmicpc.net/problem/11049
+
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+arrays = list(map(int, input().split()))
+for _ in range(n - 1):
+    r, c = map(int, input().split())
+    arrays.append(c)
+
+dp = [ [0] * n for _ in range(n) ]
+for col in range(n):
+    for i in range(n - col):
+        j = col + i
+
+        if i == j:
+            continue
+
+        dp[i][j] = 1e9
+        for k in range(i, j):
+            dp[i][j] = min(dp[i][j], dp[i][k] + dp[k + 1][j] + arrays[i] * arrays[k + 1] * arrays[j + 1])
+
+print(dp[0][-1])


### PR DESCRIPTION
## 문제 번호
<!-- 문제 번호와 문제 이름을 적어주세요. ex.) 10828번 스택 -->
<!-- 문제에 대한 이슈를 생성하였다면 이슈번호와 함께 이슈를 닫아주세요. ex.) closed #01 -->
#145 

## 풀이 사항
<!-- 어떻게 풀이했는지 아래의 정보를 적어주세요. -->
- 풀이 일자: 2022.05.18
- 풀이 시간: 93분 45초
- 채점 결과: 시간 초과(Python3), 정답(Pypy3)
- 시간복잡도: O(N^3)
- 문제 링크: https://www.acmicpc.net/problem/11049

## 기타 특이 사항
<!-- 문제를 풀면서 있었던 특이 사항들을 적어주세요. -->
<!-- ex.) 접근방식을 잘못 접근해 풀이시간을 길게 사용하였습니다. -->
1. DP 점화식을 세우지 못해 고민하다 풀이를 참고하였습니다.
2. 점화식을 학습한 뒤, 풀이 중에 DP테이블을 큰 숫자로 초기화 시켜주는 시점을 잘못잡아 오답처리되었습니다.
3. Python3로 컴파일 시 시간초과 처리되어 Pypy3로 컴파일 하여 정답처리 되었습니다.

DP 테이블을 활용하는 것도, DP 테이블의 index를 순회하는 방법도 어려웠어서 다시 한번 풀이가 필요한 문제입니다.